### PR TITLE
Remove the use of temp file ResultSpooler if results exceed memory size....

### DIFF
--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/SpoolingResultIterator.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/SpoolingResultIterator.java
@@ -95,6 +95,13 @@ public class SpoolingResultIterator implements PeekingResultIterator {
         try {
             // Can't be bigger than int, since it's the max of the above allocation
             int size = (int)chunk.getSize();
+            DeferredFileOutputStream spoolTo = new DeferredFileOutputStream(size, "ResultSpooler", ".bin", null) {
+                @Override
+                protected void thresholdReached() throws IOException {
+                    super.thresholdReached();
+                    chunk.close();
+                }
+            };
             DataOutputStream out = new DataOutputStream(spoolTo);
             final long maxBytesAllowed = maxSpoolToDisk == -1 ? 
             		Long.MAX_VALUE : thresholdBytes + maxSpoolToDisk;


### PR DESCRIPTION
Don't create temp files to store results if they surpass a certain memory threshold. Our query results should fit in memory just fine and we were having issues with the temp files not getting cleaned up and killing our hosts. 
